### PR TITLE
Fix rotated PDF documents

### DIFF
--- a/remarks/remarks.py
+++ b/remarks/remarks.py
@@ -118,7 +118,12 @@ def process_document(
 
                 # if the background page is not empty, need to merge svg on top of background page
                 if page.get_contents() != []:
+                    page_rotation = page.rotation
+                    page.set_rotation(0) # Honestly not sure why this is needed since we're also inverting rotation below, but it is...
                     w_bg, h_bg = page.cropbox.width, page.cropbox.height
+                    if int(page_rotation) in [90, 270]:
+                        # Swap height and width for rotated pages
+                        w_bg, h_bg = h_bg, w_bg
                     # find the (top, right) coordinates of the svg
                     x_shift, y_shift, w_svg, h_svg = 0, 0, PAGE_WIDTH_PT, PAGE_HEIGHT_PT
                     with open(temp_svg.name, "r") as f:
@@ -156,7 +161,14 @@ def process_document(
                                         height=height)
                     page.show_pdf_page(fitz.Rect(x_bg, y_bg, x_bg + w_bg, y_bg + h_bg),
                                        rmc_pdf_src,
+<<<<<<< HEAD
                                        page_idx)
+=======
+                                       page_idx,
+                                       # The rect above is in rotated coordinates, so we need to rotate the page to match
+                                       # ... why this needs to be the negative of the page rotation is beyond me though...
+                                       rotate=-page_rotation)
+>>>>>>> a757d7e (Fix rotated documents)
                     page.show_pdf_page(fitz.Rect(x_svg, y_svg, x_svg + w_svg, y_svg + h_svg),
                                        svg_pdf,
                                        0)


### PR DESCRIPTION
I have a PDF that's in landscape mode, apparently via rotation, this fixes the rendering of annotations.

To be 100% transparent, I don't entirely know why some of this works. As far as I can tell, the `cropbox` is in un-rotated coordinates, so it makes sense that we have to swap height/width for the page `rect` calculation, since the annotations from the tablet are in rotated coordinates.

However, why the bits `set_rotation(0)` and `rotate=-page_rotation`  are needed is completely beyond me :shrug: 