### PR TITLE
Configurable temp dir + fail-fast writable check

### DIFF
--- a/remarks/remarks.py
+++ b/remarks/remarks.py
@@ -28,6 +28,10 @@ from .utils import (
 )
 from .warnings import scrybble_warning_only_v6_supported
 
+# Optional override for where temporary files are written. Defaults to None, i.e. the
+# system temp dir (which itself honors $TMPDIR). Lets self-hosters point temp at a
+# writable volume when running in a hardened / read-only-root container.
+REMARKS_TEMP_DIR = os.getenv("REMARKS_TEMP_DIR") or None
 
 
 def run_remarks(
@@ -35,7 +39,7 @@ def run_remarks(
         device: str = None
 ):
     if input_dir.name.endswith(".rmn") or input_dir.name.endswith(".rmdoc"):
-        temp_dir = tempfile.mkdtemp()
+        temp_dir = tempfile.mkdtemp(dir=REMARKS_TEMP_DIR)
         with zipfile.ZipFile(input_dir, 'r') as zip_ref:
             zip_ref.extractall(temp_dir)
         input_dir = pathlib.Path(temp_dir)
@@ -134,7 +138,7 @@ def process_document(
                 set_device('RMPP')
 
             (ann_data, has_ann_hl), version = parse_rm_file(rm_annotation_file)
-            temp_pdf = tempfile.NamedTemporaryFile(suffix=".pdf", mode="w", delete=False)
+            temp_pdf = tempfile.NamedTemporaryFile(suffix=".pdf", mode="w", delete=False, dir=REMARKS_TEMP_DIR)
 
             # This offset is used for smart highlights
             highlights_x_translation = 0

--- a/remarks/remarks.py
+++ b/remarks/remarks.py
@@ -25,13 +25,11 @@ from .utils import (
     get_document_filetype,
     get_visible_name,
     get_ui_path,
+    get_writable_tempdir,
 )
 from .warnings import scrybble_warning_only_v6_supported
 
-# Optional override for where temporary files are written. Defaults to None, i.e. the
-# system temp dir (which itself honors $TMPDIR). Lets self-hosters point temp at a
-# writable volume when running in a hardened / read-only-root container.
-REMARKS_TEMP_DIR = os.getenv("REMARKS_TEMP_DIR") or None
+REMARKS_TEMP_DIR = get_writable_tempdir()
 
 
 def run_remarks(

--- a/remarks/server.py
+++ b/remarks/server.py
@@ -1,7 +1,6 @@
 import logging
 import pathlib
 import os
-import tempfile
 
 from flask import Flask, request
 
@@ -9,26 +8,6 @@ import remarks
 import sentry_sdk
 
 app = Flask("Remarks http server")
-
-
-def _check_writable_tempdir():
-    """Fail fast with a clear message if the temp dir isn't writable.
-
-    The renderer writes temporary files for every conversion (notebook extraction,
-    SVG/PDF intermediates). In a hardened / read-only container without a writable
-    temp dir this otherwise fails deep inside processing with an opaque error.
-    Honors $REMARKS_TEMP_DIR / $TMPDIR (Python's tempfile already reads $TMPDIR).
-    """
-    tmp = os.getenv("REMARKS_TEMP_DIR") or tempfile.gettempdir()
-    try:
-        with tempfile.NamedTemporaryFile(dir=tmp, delete=True):
-            pass
-    except OSError as e:
-        logging.error(
-            "Temp directory %r is not writable: %s. Mount a writable volume there "
-            "or set REMARKS_TEMP_DIR / TMPDIR to a writable path.", tmp, e
-        )
-        raise SystemExit(1)
 
 
 def main_prod():
@@ -41,8 +20,6 @@ def main_prod():
     else:
         sentry_sdk.init(dsn=sentry_dsn, send_default_pii=True)
         logging.info("Initialized Sentry")
-
-    _check_writable_tempdir()
 
     # Gunicorn configuration
     sys.argv = [

--- a/remarks/server.py
+++ b/remarks/server.py
@@ -1,6 +1,7 @@
 import logging
 import pathlib
 import os
+import tempfile
 
 from flask import Flask, request
 
@@ -8,6 +9,27 @@ import remarks
 import sentry_sdk
 
 app = Flask("Remarks http server")
+
+
+def _check_writable_tempdir():
+    """Fail fast with a clear message if the temp dir isn't writable.
+
+    The renderer writes temporary files for every conversion (notebook extraction,
+    SVG/PDF intermediates). In a hardened / read-only container without a writable
+    temp dir this otherwise fails deep inside processing with an opaque error.
+    Honors $REMARKS_TEMP_DIR / $TMPDIR (Python's tempfile already reads $TMPDIR).
+    """
+    tmp = os.getenv("REMARKS_TEMP_DIR") or tempfile.gettempdir()
+    try:
+        with tempfile.NamedTemporaryFile(dir=tmp, delete=True):
+            pass
+    except OSError as e:
+        logging.error(
+            "Temp directory %r is not writable: %s. Mount a writable volume there "
+            "or set REMARKS_TEMP_DIR / TMPDIR to a writable path.", tmp, e
+        )
+        raise SystemExit(1)
+
 
 def main_prod():
     """Production entry point using Gunicorn"""
@@ -19,6 +41,8 @@ def main_prod():
     else:
         sentry_sdk.init(dsn=sentry_dsn, send_default_pii=True)
         logging.info("Initialized Sentry")
+
+    _check_writable_tempdir()
 
     # Gunicorn configuration
     sys.argv = [

--- a/remarks/utils.py
+++ b/remarks/utils.py
@@ -1,6 +1,8 @@
 import json
+import os
 import pathlib
 import re
+import tempfile
 from functools import cache
 from typing import Tuple, List
 
@@ -9,6 +11,19 @@ RM_WIDTH = 1404
 RM_HEIGHT = 1872
 
 INSERTED_PAGE = -1
+
+
+def get_writable_tempdir() -> str:
+    tmp = os.getenv("REMARKS_TEMP_DIR") or tempfile.gettempdir()
+    try:
+        with tempfile.NamedTemporaryFile(dir=tmp, delete=True):
+            pass
+    except OSError as e:
+        raise SystemExit(
+            f"Temp directory {tmp!r} is not writable: {e}. "
+            "Set REMARKS_TEMP_DIR or TMPDIR to a writable path."
+        )
+    return tmp
 
 
 @cache


### PR DESCRIPTION
The renderer writes temporary files for every conversion (notebook extraction, SVG/PDF intermediates). In a hardened / read-only-root container without a writable temp dir, this otherwise fails deep inside processing with an opaque error.

- Honor `REMARKS_TEMP_DIR` (default = system temp, which already honors `$TMPDIR`) at the `mkdtemp` / `NamedTemporaryFile` sites in `remarks/remarks.py`.
- Add a startup check in `main_prod` that exits with a clear, actionable message if the temp dir isn't writable.

Defaults unchanged. `py_compile` clean; the fail-fast path verified to `SystemExit(1)` on a non-writable dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
