### PR TITLE
Emit annotation page count as a sidecar in the output zip

### DIFF
--- a/remarks/remarks.py
+++ b/remarks/remarks.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import pathlib
@@ -222,3 +223,6 @@ def process_document(
 
     output_obsidian_path = output_dir/f"{relative_doc_path}"
     obsidian_markdown.save(output_obsidian_path)
+
+    sidecar_path = output_dir/f"{relative_doc_path} _scrybble.json"
+    sidecar_path.write_text(json.dumps({"annotation_pages": len(document.rm_annotation_files)}))


### PR DESCRIPTION
Adds a small `<doc> _scrybble.json` sidecar next to the rendered `_remarks.pdf` / `_obsidian.md`, containing:
```json
{"annotation_pages": N}
```
where N is the number of `.rm` annotation files (pages with handwriting/ink). It's 0 for a document that was added but never annotated (e.g. a blank daily-journal PDF).

**Why:** a client can't reliably tell a real handwritten note from an un-annotated PDF by file size (a blank multi-page template is bigger than a one-page note) or by markdown emptiness (handwriting-only notebooks also produce empty markdown). The annotation-file count is the authoritative signal, and only the renderer has it. This lets the Obsidian plugin's automatic sync skip empty documents instead of cluttering the vault.

Additive and backward-compatible: it's one extra file in the output dir; existing consumers that pick out the pdf/md ignore it.

**Verified:** rendered a real un-annotated PDF end-to-end; produces `… _scrybble.json` = `{"annotation_pages": 0}` alongside the normal outputs.