### PR TITLE
Reduce generated pdf sizes with garbage collection

### DIFF
--- a/remarks/remarks.py
+++ b/remarks/remarks.py
@@ -220,7 +220,7 @@ def process_document(
 
     output_pdf_path = output_dir/f"{relative_doc_path} _remarks.pdf"
     output_pdf_path.parent.mkdir(parents=True, exist_ok=True)
-    rmc_pdf_src.save(output_pdf_path)
+    rmc_pdf_src.ez_save(output_pdf_path, garbage=4)
 
     output_obsidian_path = output_dir/f"{relative_doc_path}"
     obsidian_markdown.save(output_obsidian_path)


### PR DESCRIPTION
Enables garbage collection from PyMuPDF when saving.

I noticed that when generating annotated PDFs they are almost always around 2x the original filesize.

That's because when remarks generates the annotated pages and deletes the old ones they get left behind as unused pdf objects, and when saving without garbage collection it will take up twice as much space.

This PR fixes it by enabling garbage collection in the PyMuPDF save command :)